### PR TITLE
Fix CLI log commands to support log4j2 changes

### DIFF
--- a/cmd/cmd/logLevel.go
+++ b/cmd/cmd/logLevel.go
@@ -24,8 +24,8 @@ import (
 
 // List APIs command related usage info
 const logLevelCmdLiteral = "log-level"
-const logLevelCmdShortDesc = "Manage log4j properties"
-const logLevelCmdLongDesc = "Update and view log4j properties in the Micro Integrator"
+const logLevelCmdShortDesc = "Manage log4j2 properties"
+const logLevelCmdLongDesc = "Update and view log4j2 properties in the Micro Integrator"
 
 // apisListCmd represents the list apis command
 var logLevelCmd = &cobra.Command{

--- a/cmd/cmd/logLevelShow.go
+++ b/cmd/cmd/logLevelShow.go
@@ -37,7 +37,7 @@ var showLogLevelCmdUsage = "Usage:\n" +
 
 var showLogLevelCmdExamples = "Example:\n" +
 	"To get details about a specific logger\n" +
-	"  " + programName + " " + logLevelCmdLiteral + " " + showLogLevelCmdLiteral + " org.apache.coyote\n\n"
+	"  " + programName + " " + logLevelCmdLiteral + " " + showLogLevelCmdLiteral + " org-apache-coyote\n\n"
 
 // loggerShowCmd represents the show logger command
 var loggerShowCmd = &cobra.Command{
@@ -94,10 +94,10 @@ func executeGetLoggerCmd(loggerName string) {
 }
 
 // Print the details of a Logger
-// Name, Parent and loglevel
+// loggerName, componentName and loglevel
 // @param logger : Logger object
 func printLoggerInfo(logger utils.Logger) {
-	fmt.Println("Name - " + logger.Name)
+	fmt.Println("LoggerName - " + logger.LoggerName)
 	fmt.Println("LogLevel - " + logger.LogLevel)
-	fmt.Println("Parent - " + logger.ParentName)
+	fmt.Println("ComponentName - " + logger.ComponentName)
 }

--- a/cmd/cmd/logLevelUpdate.go
+++ b/cmd/cmd/logLevelUpdate.go
@@ -36,7 +36,7 @@ var updateLogLevelCmdUsage = "Usage:\n" +
 	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " [logger-name] [log-level]\n\n"
 
 var updateLogLevelCmdExamples = "Example:\n" +
-	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " org.apache.coyote DEBUG\n\n"
+	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " org-apache-coyote DEBUG\n\n"
 
 var updateLogLevelCmdHelpString = updateLogLevelCmdLongDesc + updateLogLevelCmdUsage + updateLogLevelCmdExamples
 

--- a/cmd/utils/structs.go
+++ b/cmd/utils/structs.go
@@ -41,9 +41,9 @@ type RemoteInfo struct {
 }
 
 type Logger struct {
-	Name       string `json:"name"`
-	ParentName string `json:"parent"`
-	LogLevel   string `json:"level"`
+	LoggerName    string `json:"loggerName"`
+	ComponentName string `json:"componentName"`
+	LogLevel      string `json:"level"`
 }
 
 type Service struct {


### PR DESCRIPTION
## Purpose
> This PR fixes the issue in CLI log commands which happens because of log4j2 upgrade.

Related PRs: https://github.com/wso2/micro-integrator/pull/1158