### PR TITLE
Implement authenticated calls to update logger level from MI CLI

### DIFF
--- a/cmd/cmd/logLevelUpdate.go
+++ b/cmd/cmd/logLevelUpdate.go
@@ -76,6 +76,11 @@ func printUpdateLoggerHelp() {
 }
 
 func executeUpdateLoggerCmd(loggerName, logLevel string) {
-	resp := utils.UpdateMILogger(loggerName, logLevel)
-	fmt.Println(resp)
+	resp, err := utils.UpdateMILogger(loggerName, logLevel)
+
+	if err != nil {
+		fmt.Println(utils.LogPrefixError+"Updating log level of the Logger", err)
+	} else {
+		fmt.Println(resp)
+	}
 }

--- a/cmd/cmd/logLevelUpdate.go
+++ b/cmd/cmd/logLevelUpdate.go
@@ -79,7 +79,7 @@ func executeUpdateLoggerCmd(loggerName, logLevel string) {
 	resp, err := utils.UpdateMILogger(loggerName, logLevel)
 
 	if err != nil {
-		fmt.Println(utils.LogPrefixError+"Updating log level of the Logger", err)
+		fmt.Println(utils.LogPrefixError + "Updating log level of the Logger", err)
 	} else {
 		fmt.Println(resp)
 	}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -188,7 +188,7 @@ func UpdateMILogger(loggerName, loggingLevel string) (interface{}, error) {
 	resp, err := InvokeUPDATERequest(url, headers, body)
 
 	if err != nil {
-		HandleErrorAndExit("Unable to connect to " + url, nil)
+		HandleErrorAndExit("Unable to connect to " + url, err)
 	}
 
 	Logln(LogPrefixInfo+"Response:", resp.Status())

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -171,7 +171,7 @@ func UnmarshalData(url string, headers map[string]string, params map[string]stri
 	}
 }
 
-func UpdateMILogger(loggerName, loggingLevel string) string {
+func UpdateMILogger(loggerName, loggingLevel string) (interface{}, error) {
 
 	url := GetRESTAPIBase() + PrefixLogging
 	Logln(LogPrefixInfo+"URL:", url)
@@ -180,18 +180,33 @@ func UpdateMILogger(loggerName, loggingLevel string) string {
 	body["loggerName"] = loggerName
 	body["loggingLevel"] = loggingLevel
 
+	if headers[HeaderAuthorization] == "" {
+		headers[HeaderAuthorization] = HeaderValueAuthPrefixBearer + " " +
+			RemoteConfigData.Remotes[RemoteConfigData.CurrentRemote].AccessToken
+	}
+
 	resp, err := InvokeUPDATERequest(url, headers, body)
 
 	if err != nil {
-		HandleErrorAndExit("Unable to connect to host", nil)
+		HandleErrorAndExit("Unable to connect to " + url, nil)
 	}
 
 	Logln(LogPrefixInfo+"Response:", resp.Status())
-	data := UnmarshalJsonToStringMap(resp.Body())
-	if resp.StatusCode() == http.StatusOK {
-		return data["message"]
+
+	if resp.StatusCode() == http.StatusUnauthorized {
+		// not logged in to MI
+		fmt.Println("User not logged in or session timed out. Please login to the current Micro Integrator instance")
+		fmt.Println("Execute '" + ProjectName + " remote login --help' for more information")
+	}
+	if len(resp.Body()) == 0 {
+		return nil, errors.New(resp.Status())
 	} else {
-		return data["Error"]
+		data := UnmarshalJsonToStringMap(resp.Body())
+		if resp.StatusCode() == http.StatusOK {
+			return data["message"], nil
+		} else {
+			return nil, errors.New(data["Error"])
+		}
 	}
 }
 


### PR DESCRIPTION
## Purpose
After logging in to the MI CLI, we need to make authenticated calls to update log level of a logger. 
This PR implements authenticated calls to update MI log level from CLI (from the UpdateMILogger function we need to make calls to the management API with authorization header).

If user is not logged in and a call is made to the management api to update the log level of a logger the following error will be printed (same as what we print for other cli commands),

```
User not logged in or session timed out. Please login to the current Micro Integrator instance
Execute 'mi remote login --help' for more information
[ERROR] Updating log level of the Logger 401 Unauthorized
```