### PR TITLE
Fix CLI remote login password issue in windows

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/crypto/ssh/terminal"
@@ -82,7 +83,7 @@ func PromptForUsername() string {
 
 func PromptForPassword() string {
 	fmt.Print("Enter Password: ")
-	bytePassword, _ := terminal.ReadPassword(0)
+	bytePassword, _ := terminal.ReadPassword(int(syscall.Stdin))
 	password := string(bytePassword)
 	fmt.Println()
 	return strings.TrimSpace(password)


### PR DESCRIPTION
## Purpose
The fact that `0 == syscall.Stdin` on Unix system does not mean that holds true on Windows (i.e. 0 is not stdin handler in Windows). [More info](https://github.com/golang/go/issues/11914) 

We can make this code work cross-platform by using `terminal.ReadPassword(int(syscall.Stdin)) `instead of 0.

Related Issue: https://github.com/wso2/micro-integrator/issues/1034
