### PR TITLE
Add Docker resources for Micro Integrator Dashboard

### DIFF
--- a/monitoring-dashboard/distribution/pom.xml
+++ b/monitoring-dashboard/distribution/pom.xml
@@ -208,7 +208,7 @@
                 <executions>
                     <execution>
                         <id>p2-repo-generation</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>generate-repo</goal>
                         </goals>
@@ -311,7 +311,7 @@
                     </execution>
                     <execution>
                         <id>publishing products</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>publish-product</goal>
                         </goals>
@@ -324,7 +324,7 @@
                     </execution>
                     <execution>
                         <id>materialize-monitoring-dashboard</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>generate-runtime</goal>
                         </goals>
@@ -338,7 +338,7 @@
                     </execution>
                     <execution>
                         <id>feature-installation-monitoring-dashboard</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>install</goal>
                         </goals>
@@ -445,6 +445,31 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.2</version>
+                <executions>
+                    <execution>
+                        <id>distribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>${basedir}/src/assembly/filter.properties</filter>
+                            </filters>
+                            <descriptors>
+                                <descriptor>${basedir}/src/assembly/bin.xml</descriptor>
+                            </descriptors>
+                            <finalName>wso2mi-monitoring-dashboard-${project.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
@@ -462,13 +487,31 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <configuration>
                             <tasks>
                                 <replace dir="target/wso2carbon-kernel-${carbon.kernel5.version}/wso2" token="false" value="true">
                                     <include name="**/bundles.info" />
                                 </replace>
                             </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>prepare</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <skip>${docker.skip}</skip>
+                            <target>
+                                <echo message="prepare phase" />
+                                <unzip src="${project.build.directory}/wso2mi-monitoring-dashboard-${project.version}.zip" dest="${project.build.directory}/docker" />
+                                <move file="${project.build.directory}/docker/wso2mi-monitoring-dashboard-${project.version}" tofile="${project.build.directory}/docker/wso2mi-monitoring-dashboard" />
+                                <chmod file="${project.build.directory}/docker/wso2mi-monitoring-dashboard/bin/*.sh" perm="+x" />
+                                <chmod file="${project.build.directory}/docker/wso2mi-monitoring-dashboard/wso2/server/bin/*.sh" perm="+x" />
+                                <chmod file="${project.build.directory}/docker/docker-entrypoint.sh" perm="+x" />
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>
@@ -501,29 +544,102 @@
 
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
+                <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>distribution</id>
-                        <phase>package</phase>
+                        <id>docker-entry-file</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <filters>
-                                <filter>${basedir}/src/assembly/filter.properties</filter>
-                            </filters>
-                            <descriptors>
-                                <descriptor>${basedir}/src/assembly/bin.xml</descriptor>
-                            </descriptors>
-                            <finalName>wso2mi-monitoring-dashboard-${project.version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/src/docker-distribution</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>docker-entrypoint.sh</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                            <outputDirectory>${project.build.directory}/docker</outputDirectory>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-image-alpine</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skipDocker>${docker.skip}</skipDocker>
+                            <imageName>wso2/micro-integrator-dashboard</imageName>
+                            <imageTags>
+                                <imageTag>${project.version}</imageTag>
+                            </imageTags>
+                            <dockerDirectory>${basedir}/src/docker-distribution/alpine</dockerDirectory>
+                            <buildArgs>
+                                <MICROESB_DASHBOARD_VERSION>${project.version}</MICROESB_DASHBOARD_VERSION>
+                            </buildArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build-image-centos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skipDocker>${docker.skip}</skipDocker>
+                            <imageName>wso2/micro-integrator-dashboard</imageName>
+                            <imageTags>
+                                <imageTag>${project.version}-centos7</imageTag>
+                            </imageTags>
+                            <dockerDirectory>${basedir}/src/docker-distribution/centos</dockerDirectory>
+                            <buildArgs>
+                                <MICROESB_DASHBOARD_VERSION>${project.version}</MICROESB_DASHBOARD_VERSION>
+                            </buildArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>build-image-ubuntu</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <skipDocker>${docker.skip}</skipDocker>
+                            <imageName>wso2/micro-integrator-dashboard</imageName>
+                            <imageTags>
+                                <imageTag>${project.version}-ubuntu18.04</imageTag>
+                            </imageTags>
+                            <dockerDirectory>${basedir}/src/docker-distribution/ubuntu</dockerDirectory>
+                            <buildArgs>
+                                <MICROESB_DASHBOARD_VERSION>${project.version}</MICROESB_DASHBOARD_VERSION>
+                            </buildArgs>
+                        </configuration>
+                    </execution>
+                    <!-- TODO Enable after configuring Jenkins to push docker -->
+                    <!--<execution>-->
+                    <!--<id>push-image</id>-->
+                    <!--<phase>deploy</phase>-->
+                    <!--<goals>-->
+                    <!--<goal>push</goal>-->
+                    <!--</goals>-->
+                    <!--<configuration>-->
+                    <!--<configuration>-->
+                    <!--<imageName>wso2/micro-integrator:${project.version}</imageName>-->
+                    <!--</configuration>-->
+                    <!--</execution>-->
                 </executions>
             </plugin>
         </plugins>
@@ -538,4 +654,8 @@
             </resource>
         </resources>
     </build>
+
+    <properties>
+        <docker.skip>true</docker.skip>
+    </properties>
 </project>

--- a/monitoring-dashboard/distribution/src/docker-distribution/alpine/Dockerfile
+++ b/monitoring-dashboard/distribution/src/docker-distribution/alpine/Dockerfile
@@ -1,0 +1,62 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# ---------------------------------------------------------------------------
+
+# set base Docker image to AdoptOpenJDK Alpine Docker image
+FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# docker image build arguments for Micro Integrator Dashboard installation
+ARG MICROESB_DASHBOARD_NAME=wso2mi-monitoring-dashboard
+
+# get the Micro Integrator Dashboard version which is passed as a build argument and assert to be not empty
+ARG MICROESB_DASHBOARD_VERSION
+RUN test -n "$MICROESB_DASHBOARD_VERSION"
+
+ARG MICROESB_DASHBOARD_SERVER=${MICROESB_DASHBOARD_NAME}-${MICROESB_DASHBOARD_VERSION}
+ARG MICROESB_DASHBOARD_HOME=${USER_HOME}/${MICROESB_DASHBOARD_SERVER}
+
+# create the user and group
+RUN \
+    addgroup --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && adduser --system --home ${USER_HOME} -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
+
+# copy Micro Intergator Dashboard distribution to user's home directory
+COPY --chown=wso2carbon:wso2 ${MICROESB_DASHBOARD_NAME}/ ${MICROESB_DASHBOARD_HOME}
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# set the user and work directory
+USER ${USER}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${MICROESB_DASHBOARD_HOME}
+
+# expose Micro Integrator ports
+EXPOSE 9743 9164
+
+# initiate container and execute the Micro Integrator Dashboard startup script
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/monitoring-dashboard/distribution/src/docker-distribution/centos/Dockerfile
+++ b/monitoring-dashboard/distribution/src/docker-distribution/centos/Dockerfile
@@ -1,0 +1,62 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# ---------------------------------------------------------------------------
+
+# set base Docker image to AdoptOpenJDK CentOS Docker image
+FROM adoptopenjdk/openjdk8:x86_64-centos-jre8u242-b08
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# docker image build arguments for Micro Integrator Dashboard installation
+ARG MICROESB_DASHBOARD_NAME=wso2mi-monitoring-dashboard
+
+# get the Micro Integrator Dashboard version which is passed as a build argument and assert to be not empty
+ARG MICROESB_DASHBOARD_VERSION
+RUN test -n "$MICROESB_DASHBOARD_VERSION"
+
+ARG MICROESB_DASHBOARD_SERVER=${MICROESB_DASHBOARD_NAME}-${MICROESB_DASHBOARD_VERSION}
+ARG MICROESB_DASHBOARD_HOME=${USER_HOME}/${MICROESB_DASHBOARD_SERVER}
+
+# create the user and group
+RUN \
+    groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && useradd --system --home ${USER_HOME} -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
+
+# copy Micro Intergator Dashboard distribution to user's home directory
+COPY --chown=wso2carbon:wso2 ${MICROESB_DASHBOARD_NAME}/ ${MICROESB_DASHBOARD_HOME}
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# set the user and work directory
+USER ${USER}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${MICROESB_DASHBOARD_HOME}
+
+# expose Micro Integrator ports
+EXPOSE 9743 9164
+
+# initiate container and execute the Micro Integrator Dashboard startup script
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/monitoring-dashboard/distribution/src/docker-distribution/docker-entrypoint.sh
+++ b/monitoring-dashboard/distribution/src/docker-distribution/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# ---------------------------------------------------------------------------
+
+set -e
+
+# check if the WSO2 non-root user home exists
+test ! -d "${WORKING_DIRECTORY}" && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# check if the WSO2 product home exists
+test ! -d "${WSO2_SERVER_HOME}" && echo "WSO2 Docker product home does not exist" && exit 1
+
+# start Micro Integrator Dashboard
+sh "${WSO2_SERVER_HOME}"/bin/dashboard.sh "$@"

--- a/monitoring-dashboard/distribution/src/docker-distribution/ubuntu/Dockerfile
+++ b/monitoring-dashboard/distribution/src/docker-distribution/ubuntu/Dockerfile
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  WSO2 Inc. licenses this file to you under the Apache License,
+#  Version 2.0 (the "License"); you may not use this file except
+#  in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied. See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+# ---------------------------------------------------------------------------
+
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jre8u242-b08
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+
+# set Docker image build arguments
+# build arguments for user/group configurations
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# docker image build arguments for Micro Integrator Dashboard installation
+ARG MICROESB_DASHBOARD_NAME=wso2mi-monitoring-dashboard
+
+# get the Micro Integrator Dashboard version which is passed as a build argument and assert to be not empty
+ARG MICROESB_DASHBOARD_VERSION
+RUN test -n "$MICROESB_DASHBOARD_VERSION"
+
+ARG MICROESB_DASHBOARD_SERVER=${MICROESB_DASHBOARD_NAME}-${MICROESB_DASHBOARD_VERSION}
+ARG MICROESB_DASHBOARD_HOME=${USER_HOME}/${MICROESB_DASHBOARD_SERVER}
+
+# create the user and group
+RUN \
+    groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && useradd --system --home ${USER_HOME} -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
+
+# copy Micro Intergator Dashboard distribution to user's home directory
+COPY --chown=wso2carbon:wso2 ${MICROESB_DASHBOARD_NAME}/ ${MICROESB_DASHBOARD_HOME}
+# copy init script to user home
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+# set the user and work directory
+USER ${USER}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${MICROESB_DASHBOARD_HOME}
+
+# expose Micro Integrator ports
+EXPOSE 9743 9164
+
+# initiate container and execute the Micro Integrator Dashboard startup script
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <!--<jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>-->
         <!--<testng.version>6.11</testng.version>-->
         <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
+        <docker.maven.plugin.version>1.0.0</docker.maven.plugin.version>
 
     </properties>
 


### PR DESCRIPTION
## Purpose
Add docker resource for Micro Integrator Dashboard for the following OS platforms.

- [x] Ubuntu
- [x] Alpine
- [x] Centos

Related issue: https://github.com/wso2/micro-integrator/issues/1089