### PR TITLE
Support updating state of message processor through CLI

### DIFF
--- a/cmd/cmd/messageProcessorUpdate.go
+++ b/cmd/cmd/messageProcessorUpdate.go
@@ -24,18 +24,19 @@ import (
 	"github.com/wso2/product-mi-tooling/cmd/utils"
 )
 
-var messageProcessorState string
+var messageProcessorStateValue string
 // Show API command related usage info
 const updateMessageProcessorCmdLiteral = "update"
+const messageProcessorState = "state"
 const updateMessageProcessorCmdShortDesc = "Update state of messageprocessor"
 
 const updateMessageProcessorCmdLongDesc = "Update state of messageprocessor in Micro Integrator\n"
 
 var updateMessageProcessorCmdUsage = "Usage:\n" +
-	"  " + programName + " " + messageProcessorCmdLiteral + " " + updateMessageProcessorCmdLiteral + " [messageprocessor-name] [state]\n\n"
+	"  " + programName + " " + messageProcessorCmdLiteral + " " + updateMessageProcessorCmdLiteral + " [messageprocessor-name] " + messageProcessorState + " [state]\n\n"
 
 var updateMessageProcessorCmdExamples = "Example:\n" +
-	"  " + programName + " " + messageProcessorCmdLiteral + " " + updateMessageProcessorCmdLiteral + " TestMessageProcessor inactive\n\n"
+	"  " + programName + " " + messageProcessorCmdLiteral + " " + updateMessageProcessorCmdLiteral + " TestMessageProcessor state inactive\n\n"
 
 var updateMessageProcessorCmdHelpString = updateMessageProcessorCmdLongDesc + updateMessageProcessorCmdUsage + updateMessageProcessorCmdExamples
 
@@ -56,26 +57,32 @@ func init() {
 
 func handleUpdateMessageProcessorCmdArguments(args []string) {
 	utils.Logln(utils.LogPrefixInfo + "Update message processor called")
-	if len(args) == 2 {
-		if args[0] == "help" || args[1] == "help" {
+	if len(args) == 3 {
+		if args[0] == "help" || args[1] == "help" || args[2] == "help" {
 			printUpdateMessageProcessorHelp()
+		} else if args[1] != messageProcessorState {
+			printInvalidCommandMessage(args)
 		} else {
 			messageProcessorName = args[0]
-			messageProcessorState = args[1]
-			executeUpdateMessageProcessorCmd(messageProcessorName, messageProcessorState)
+			messageProcessorStateValue = args[2]
+			executeUpdateMessageProcessorCmd(messageProcessorName, messageProcessorStateValue)
 		}
 	} else {
-		fmt.Println(programName, "message processor update requires 2 arguments. See the usage below")
-		printUpdateMessageProcessorHelp()
+		printInvalidCommandMessage(args)
 	}
 }
 
+func printInvalidCommandMessage(args []string) {
+	fmt.Println("messageprocessor update:", args, "is not a valid command.\n" +
+		programName, "messageprocessor update requires 2 arguments. See the usage below.")
+	printUpdateMessageProcessorHelp()
+}
 func printUpdateMessageProcessorHelp() {
 	fmt.Print(updateMessageProcessorCmdHelpString)
 }
 
-func executeUpdateMessageProcessorCmd(messageProcessorName, messageProcessorState string) {
-	resp, err := utils.UpdateMIMessageProcessor(messageProcessorName, messageProcessorState)
+func executeUpdateMessageProcessorCmd(messageProcessorName, messageProcessorStateValue string) {
+	resp, err := utils.UpdateMIMessageProcessor(messageProcessorName, messageProcessorStateValue)
 
 	if err != nil {
 		fmt.Println(utils.LogPrefixError + "Updating state of message processor: ", err)

--- a/cmd/cmd/messageProcessorUpdate.go
+++ b/cmd/cmd/messageProcessorUpdate.go
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-mi-tooling/cmd/utils"
+)
+
+var messageProcessorState string
+// Show API command related usage info
+const updateMessageProcessorCmdLiteral = "update"
+const updateMessageProcessorCmdShortDesc = "Update state of messageprocessor"
+
+const updateMessageProcessorCmdLongDesc = "Update state of messageprocessor in Micro Integrator\n"
+
+var updateMessageProcessorCmdUsage = "Usage:\n" +
+	"  " + programName + " " + messageProcessorCmdLiteral + " " + updateMessageProcessorCmdLiteral + " [messageprocessor-name] [state]\n\n"
+
+var updateMessageProcessorCmdExamples = "Example:\n" +
+	"  " + programName + " " + messageProcessorCmdLiteral + " " + updateMessageProcessorCmdLiteral + " TestMessageProcessor inactive\n\n"
+
+var updateMessageProcessorCmdHelpString = updateMessageProcessorCmdLongDesc + updateMessageProcessorCmdUsage + updateMessageProcessorCmdExamples
+
+// messageProcessorUpdateCmd represents the update messageProcessor state command
+var messageProcessorUpdateCmd = &cobra.Command{
+	Use:   updateMessageProcessorCmdLiteral,
+	Short: updateMessageProcessorCmdShortDesc,
+	Long:  updateMessageProcessorCmdLongDesc + updateMessageProcessorCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		handleUpdateMessageProcessorCmdArguments(args)
+	},
+}
+
+func init() {
+	messageProcessorCmd.AddCommand(messageProcessorUpdateCmd)
+	messageProcessorUpdateCmd.SetHelpTemplate(updateMessageProcessorCmdHelpString + utils.GetCmdFlags(updateMessageProcessorCmdLiteral))
+}
+
+func handleUpdateMessageProcessorCmdArguments(args []string) {
+	utils.Logln(utils.LogPrefixInfo + "Update message processor called")
+	if len(args) == 2 {
+		if args[0] == "help" || args[1] == "help" {
+			printUpdateMessageProcessorHelp()
+		} else {
+			messageProcessorName = args[0]
+			messageProcessorState = args[1]
+			executeUpdateMessageProcessorCmd(messageProcessorName, messageProcessorState)
+		}
+	} else {
+		fmt.Println(programName, "message processor update requires 2 arguments. See the usage below")
+		printUpdateMessageProcessorHelp()
+	}
+}
+
+func printUpdateMessageProcessorHelp() {
+	fmt.Print(updateMessageProcessorCmdHelpString)
+}
+
+func executeUpdateMessageProcessorCmd(messageProcessorName, messageProcessorState string) {
+	resp, err := utils.UpdateMIMessageProcessor(messageProcessorName, messageProcessorState)
+
+	if err != nil {
+		fmt.Println(utils.LogPrefixError + "Updating state of message processor: ", err)
+	} else {
+		fmt.Println("Message processor ", resp)
+	}
+}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -375,14 +375,14 @@ func CreateKeyValuePairs(mapData map[string]string) string {
 	}
 }
 
-func UpdateMIMessageProcessor(messageProcessorName, messageProcessorState string) (interface{}, error) {
+func UpdateMIMessageProcessor(messageProcessorName, messageProcessorStateValue string) (interface{}, error) {
 
 	url := GetRESTAPIBase() + PrefixMessageProcessors
-	Logln(LogPrefixInfo+"URL:", url)
+	Logln(LogPrefixInfo + "URL:", url)
 	headers := make(map[string]string)
 	body := make(map[string]string)
 	body["name"] = messageProcessorName
-	body["status"] = messageProcessorState
+	body["status"] = messageProcessorStateValue
 
 	if headers[HeaderAuthorization] == "" {
 		headers[HeaderAuthorization] = HeaderValueAuthPrefixBearer + " " +

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -375,6 +375,46 @@ func CreateKeyValuePairs(mapData map[string]string) string {
 	}
 }
 
+func UpdateMIMessageProcessor(messageProcessorName, messageProcessorState string) (interface{}, error) {
+
+	url := GetRESTAPIBase() + PrefixMessageProcessors
+	Logln(LogPrefixInfo+"URL:", url)
+	headers := make(map[string]string)
+	body := make(map[string]string)
+	body["name"] = messageProcessorName
+	body["status"] = messageProcessorState
+
+	if headers[HeaderAuthorization] == "" {
+		headers[HeaderAuthorization] = HeaderValueAuthPrefixBearer + " " +
+			RemoteConfigData.Remotes[RemoteConfigData.CurrentRemote].AccessToken
+	}
+
+	resp, err := InvokePOSTRequest(url, headers, body)
+
+	if err != nil {
+		HandleErrorAndExit("Unable to connect to " + url, err)
+	}
+
+	Logln(LogPrefixInfo + "Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusUnauthorized {
+		// not logged in to MI
+		fmt.Println("User not logged in or session timed out. Please login to the current Micro Integrator instance")
+		fmt.Println("Execute '" + ProjectName + " remote login --help' for more information")
+	}
+
+	if len(resp.Body()) == 0 {
+		return nil, errors.New(resp.Status())
+	} else {
+		data := UnmarshalJsonToStringMap(resp.Body())
+		if data["Message"] != "" {
+			return data["Message"], nil
+		} else {
+			return nil, errors.New(data["Error"])
+		}
+	}
+}
+
 func IsValidConsoleInput(inputs map[string]string) (bool) {
 	for key, input := range inputs {
 		if len(strings.TrimSpace(input)) == 0 {


### PR DESCRIPTION
## Purpose
This PR adds support for updating state of message processor using MI CLI.

**Example**
`$ mi messageprocessor update TestMessageProcessor active`
`$ mi messageprocessor update TestMessageProcessor inactive`

Fixes https://github.com/wso2/micro-integrator/issues/1538
