### PR TITLE
Fix: https://github.com/wso2/micro-integrator/issues/1666

### DIFF
--- a/monitoring-dashboard/distribution/carbon-home/runtime/server/carbon.sh
+++ b/monitoring-dashboard/distribution/carbon-home/runtime/server/carbon.sh
@@ -212,10 +212,11 @@ elif [ "$CMD" = "version" ]; then
 fi
 
 # ---------- Handle the SSL Issue with proper JDK version --------------------
-jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
-if [ "$jdk_18" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0107 ] || [ $java_version_formatted -gt 1100 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.8"
+   echo " [ERROR] CARBON is supported only on JDK 1.8, 9, 10 and 11"
 fi
 
 CARBON_XBOOTCLASSPATH=""
@@ -248,7 +249,9 @@ if $cygwin; then
   CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
   RUNTIME_HOME=`cygpath --absolute --windows "$RUNTIME_HOME"`
   CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  if [ $java_version_formatted -le 0108 ]; then
+    JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  fi
   CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
   CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
 fi
@@ -267,6 +270,15 @@ status=$START_EXIT_STATUS
 #To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
 #   -Djava.rmi.server.hostname="your.IP.goes.here"
 
+JAVA_VER_BASED_OPTS=""
+if [ $java_version_formatted -le 0108 ]; then
+    JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=$JAVA_ENDORSED_DIRS"
+fi
+
+if [ $java_version_formatted -ge 1100 ] ; then
+    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
+fi
+
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
     $JAVACMD \
@@ -276,7 +288,7 @@ do
     -XX:HeapDumpPath="$RUNTIME_HOME/logs/heap-dump.hprof" \
     $JAVA_OPTS \
     -classpath "$CARBON_CLASSPATH" \
-    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    $JAVA_VER_BASED_OPTS \
     -Djava.io.tmpdir="$CARBON_HOME/tmp" \
     -Dcarbon.registry.root=/ \
     -Djava.command="$JAVACMD" \

--- a/monitoring-dashboard/distribution/pom.xml
+++ b/monitoring-dashboard/distribution/pom.xml
@@ -151,6 +151,10 @@
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/monitoring-dashboard/distribution/src/assembly/bin.xml
+++ b/monitoring-dashboard/distribution/src/assembly/bin.xml
@@ -96,6 +96,15 @@
             <fileMode>744</fileMode>
         </fileSet>
     </fileSets>
+    <dependencySets>
+    <dependencySet>
+        <useProjectArtifact>false</useProjectArtifact>
+        <outputDirectory>bin/bootstrap</outputDirectory>
+        <includes>
+            <include>javax.annotation:javax.annotation-api:jar</include>
+        </includes>
+    </dependencySet>
+    </dependencySets>
     <files>
         <file>
             <source>carbon-home/updates/product.txt</source>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <org.snakeyml.version>1.26</org.snakeyml.version>
         <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
+        <verion.javax.annotation.annotation-api>1.3.2</verion.javax.annotation.annotation-api>
 
     </properties>
 
@@ -303,6 +304,11 @@
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
                 <version>${version.jaxb.api}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${verion.javax.annotation.annotation-api}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Purpose
Add javax.annotations jar to the classpath to support the dashboard in jdk11. And edited the carbon.sh to support jdk 11 as well.

Fixes: https://github.com/wso2/micro-integrator/issues/1666