### PR TITLE
Add logger level addition support to CLI

### DIFF
--- a/cmd/cmd/logLevelUpdate.go
+++ b/cmd/cmd/logLevelUpdate.go
@@ -32,11 +32,18 @@ const updateLogLevelCmdShortDesc = "Update log level"
 
 const updateLogLevelCmdLongDesc = "Update log level of the Loggers in Micro Integrator\n"
 
-var updateLogLevelCmdUsage = "Usage:\n" +
-	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " [logger-name] [log-level]\n\n"
+var updateLogLevelCmdUsage = "Usage:\n\n" +
+	" To update the level of an existing logger\n\n" +
+	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " [logger-name] [log-level]\n\n" +
+	" To add a new logger\n\n" +
+	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " [logger-name] [log-level]" +
+	" [class-name]\n\n"
 
-var updateLogLevelCmdExamples = "Example:\n" +
-	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " org-apache-coyote DEBUG\n\n"
+var updateLogLevelCmdExamples = "Example:\n\n" +
+	" To update the level of an existing logger\n\n" +
+	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " org-apache-coyote DEBUG\n\n" +
+	" To add a new logger\n\n" +
+	"  " + programName + " " + logLevelCmdLiteral + " " + updateLogLevelCmdLiteral + " synapse-api DEBUG org.apache.synapse.rest.API\n\n"
 
 var updateLogLevelCmdHelpString = updateLogLevelCmdLongDesc + updateLogLevelCmdUsage + updateLogLevelCmdExamples
 
@@ -57,16 +64,26 @@ func init() {
 
 func handleUpdateLoggerCmdArguments(args []string) {
 	utils.Logln(utils.LogPrefixInfo + "Update Logger called")
-	if len(args) == 2 {
+	if len(args) == 2 || len(args) == 3 {
 		if args[0] == "help" || args[1] == "help" {
 			printUpdateLoggerHelp()
 		} else {
 			loggerName = args[0]
 			logLevel = args[1]
-			executeUpdateLoggerCmd(loggerName, logLevel)
+			var logClass = ""
+			if len(args) == 3 {
+				if args[2] == "help" {
+					printUpdateLoggerHelp()
+					return
+				} else {
+					logClass = args[2]
+				}
+			}
+			executeUpdateLoggerCmd(loggerName, logLevel, logClass)
 		}
 	} else {
-		fmt.Println(programName, "log-level update requires 2 argument. See the usage below")
+		fmt.Println(programName, "log-level update accepts minimum of 2 and a maximum of 3 arguments. "+
+			"See the usage below")
 		printUpdateLoggerHelp()
 	}
 }
@@ -75,8 +92,8 @@ func printUpdateLoggerHelp() {
 	fmt.Print(updateLogLevelCmdHelpString)
 }
 
-func executeUpdateLoggerCmd(loggerName, logLevel string) {
-	resp, err := utils.UpdateMILogger(loggerName, logLevel)
+func executeUpdateLoggerCmd(loggerName, logLevel, logClass string) {
+	resp, err := utils.UpdateMILogger(loggerName, logLevel, logClass)
 
 	if err != nil {
 		fmt.Println(utils.LogPrefixError + "Updating log level of the Logger", err)

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -214,7 +214,7 @@ func UnmarshalLogFileData(url string, headers map[string]string, params map[stri
     Logln(LogPrefixInfo+"Response:", resp.Status())
 }
 
-func UpdateMILogger(loggerName, loggingLevel string) (interface{}, error) {
+func UpdateMILogger(loggerName, loggingLevel , logClass string) (interface{}, error) {
 
 	url := GetRESTAPIBase() + PrefixLogging
 	Logln(LogPrefixInfo+"URL:", url)
@@ -222,7 +222,9 @@ func UpdateMILogger(loggerName, loggingLevel string) (interface{}, error) {
 	body := make(map[string]string)
 	body["loggerName"] = loggerName
 	body["loggingLevel"] = loggingLevel
-
+	if len(logClass) > 0 {
+		body["loggerClass"] = logClass
+	}
 	if headers[HeaderAuthorization] == "" {
 		headers[HeaderAuthorization] = HeaderValueAuthPrefixBearer + " " +
 			RemoteConfigData.Remotes[RemoteConfigData.CurrentRemote].AccessToken


### PR DESCRIPTION
Fixes https://github.com/wso2/micro-integrator/issues/1587

```bash
Update log level of the Loggers in Micro Integrator
Usage:

 To update the level of an existing logger

  ./mi log-level update [logger-name] [log-level]

 To add a new logger

  ./mi log-level update [logger-name] [log-level] [class-name]

Example:

 To update the level of an existing logger

  ./mi log-level update org-apache-coyote DEBUG

 To add a new logger

  ./mi log-level update synapse-api DEBUG org.apache.synapse.rest.API
```