### PR TITLE
Move cli config to hidden folder

### DIFF
--- a/cmd/utils/fileIOUtils.go
+++ b/cmd/utils/fileIOUtils.go
@@ -42,7 +42,9 @@ func GetRemoteConfigFilePath() string {
 	if err != nil {
 		HandleErrorAndExit("Error getting user home directory: ", err)
 	}
-	remoteConfigFilePath := filepath.Join(userHomeDir, RemoteConfigFileName)
+	configDirectory := filepath.Join(userHomeDir, ConfigDirName)
+	makeDirectoryIfNotExists(configDirectory)
+	remoteConfigFilePath := filepath.Join(configDirectory, RemoteConfigFileName)
 	return remoteConfigFilePath
 }
 
@@ -63,4 +65,11 @@ func GetConfigFilePath(configFileName string) string {
 	}
 	configFilePath := filepath.Join(userHomeDir, configFileName)
 	return configFilePath
+}
+
+func makeDirectoryIfNotExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return os.Mkdir(path, os.ModeDir|0755)
+	}
+	return nil
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This PR will move cli config yaml to hidden folder called `.wso2micli`.
Resolves https://github.com/wso2/micro-integrator/issues/1755