### PR TITLE
Print authentication error when downloading log file without logging in

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -209,6 +209,12 @@ func UnmarshalLogFileData(url string, headers map[string]string, params map[stri
 
     resp, err := InvokeGETRequest(url, headers, params)
 
+	if resp.StatusCode() == http.StatusUnauthorized {
+		// not logged in to MI
+		HandleErrorAndExit("User not logged in or session timed out. Please login to the current Micro " +
+			"Integrator instance", nil)
+	}
+
     if err != nil {
         HandleErrorAndExit("Unable to connect to "+url, nil)
     }


### PR DESCRIPTION
## Purpose
Print authentication error when try to download a log file without logging in to the Micro Integrator.
Fixes https://github.com/wso2/micro-integrator/issues/1824
