### PR TITLE
Mitigate interface error when empty error response comes

### DIFF
--- a/cmd/cmd/transactionCount.go
+++ b/cmd/cmd/transactionCount.go
@@ -20,10 +20,11 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-mi-tooling/cmd/utils"
 	"github.com/wso2/product-mi-tooling/cmd/utils/artifactUtils"
-	"strconv"
 )
 
 const transactionCountCmdLiteral = "count"
@@ -75,7 +76,7 @@ func executeGetTransactionCountWithArgsCmd(year string, month string) {
 
 // Invoke ../management/transactions/count?year=[year]&month=[month]
 func executeGetTransactionCountCmd(params map[string]string) {
-	finalUrl := utils.GetRESTAPIBase() + utils.PrefixTransactions + "/"+ utils.TransactionCountCmd
+	finalUrl := utils.GetRESTAPIBase() + utils.PrefixTransactions + "/" + utils.TransactionCountCmd
 	resp, err := utils.UnmarshalData(finalUrl, nil, params, &artifactUtils.TransactionCount{})
 	handleResponse(resp, err)
 }
@@ -86,12 +87,7 @@ func handleResponse(resp interface{}, err error) {
 		transactionCount := resp.(*artifactUtils.TransactionCount)
 		printTransactionCountInfo(*transactionCount)
 	} else {
-		errBody := resp.(string)
-		if len(errBody) > 0 {
-			fmt.Println(utils.LogPrefixError+errBody, err)
-		} else {
-			fmt.Println(utils.LogPrefixError+"When getting information of Transaction Counts.", err)
-		}
+		fmt.Println(utils.LogPrefixError+"Retrieving transactions count.", err)
 	}
 }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Currently if when you try to check the transaction count without login, it is throwing an error stacktrace without showing a proper error. This PR will fix the issue.

```
user@Users-MacBook-Pro wso2mi-cli-1.2.0-SNAPSHOT % ./bin/mi transaction count
User not logged in or session timed out. Please login to the current Micro Integrator instance
Execute 'mi remote login --help' for more information
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/wso2/product-mi-tooling/cmd/cmd.handleResponse(0x0, 0x0, 0x1585bc0, 0xc000119610)
	/Users/user/wso2/product-mi-tooling/cmd/cmd/transactionCount.go:89 +0x211
github.com/wso2/product-mi-tooling/cmd/cmd.executeGetTransactionCountCmd(0x0)
	/Users/user/wso2/product-mi-tooling/cmd/cmd/transactionCount.go:80 +0xec
github.com/wso2/product-mi-tooling/cmd/cmd.handleTransactionCountCmdArguments(0x18c6ff8, 0x0, 0x0)
	/Users/user/wso2/product-mi-tooling/cmd/cmd/transactionCount.go:58 +0x42b
github.com/wso2/product-mi-tooling/cmd/cmd.glob..func30(0x1895900, 0x18c6ff8, 0x0, 0x0)
	/Users/user/wso2/product-mi-tooling/cmd/cmd/transactionCount.go:41 +0x3f
github.com/spf13/cobra.(*Command).execute(0x1895900, 0x18c6ff8, 0x0, 0x0, 0x1895900, 0x18c6ff8)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0x189cec0, 0x0, 0x0, 0x0)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/user/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/wso2/product-mi-tooling/cmd/cmd.Execute()
	/Users/user/wso2/product-mi-tooling/cmd/cmd/root.go:50 +0x2d
main.main()
	/Users/user/wso2/product-mi-tooling/cmd/mi.go:24 +0x20
```