### PR TITLE
Fix error while invoking transaction report CLI command without logging in

### DIFF
--- a/cmd/cmd/userAdd.go
+++ b/cmd/cmd/userAdd.go
@@ -133,6 +133,7 @@ func executeAddUserCmd(userId string, password string, isAdmin string) {
     } else if res.StatusCode() == http.StatusUnauthorized {
         // not logged in to MI
         fmt.Println("User not logged in or session timed out. Please login to the current Micro Integrator instance")
+        utils.HandleErrorAndExit("Execute 'mi remote login --help' for more information", nil)
     } else {
         if err == nil {
             fmt.Println(utils.LogPrefixError + errString)

--- a/cmd/cmd/userRemove.go
+++ b/cmd/cmd/userRemove.go
@@ -86,6 +86,7 @@ func executeRemoveUserCmd(userId string) {
     } else if res.StatusCode() == http.StatusUnauthorized {
         // not logged in to MI
         fmt.Println("User not logged in or session timed out. Please login to the current Micro Integrator instance")
+        utils.HandleErrorAndExit("Execute 'mi remote login --help' for more information", nil)
     } else {
         if err == nil {
             fmt.Println(utils.LogPrefixError + errString)

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -186,7 +186,7 @@ func UnmarshalData(url string, headers map[string]string, params map[string]stri
 		if resp.StatusCode() == http.StatusUnauthorized {
 			// not logged in to MI
 			fmt.Println("User not logged in or session timed out. Please login to the current Micro Integrator instance")
-			fmt.Println("Execute '" + ProjectName + " remote login --help' for more information")
+			HandleErrorAndExit("Execute '" + ProjectName + " remote login --help' for more information", nil)
 		}
 		if len(resp.Body()) == 0 {
 			return nil, errors.New(resp.Status())


### PR DESCRIPTION
## Purpose
When invoking transaction report command from MI CLI without logging in the following error occurs,
```
~/Documents/trash/wso2mi-cli-1.2.0/bin ❯ ./mi transaction report create
User not logged in or session timed out. Please login to the current Micro Integrator instance
Execute 'mi remote login --help' for more information
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/wso2/product-mi-tooling/cmd/cmd.executeTransactionReportGenerationCmd(0xc000024044, 0x36, 0x7ffeefbff880, 0x6, 0x0, 0x0)
	/Users/srivathsan/Documents/work2/product-mi-tooling/cmd/cmd/transactionReport.go:111 +0x614
github.com/wso2/product-mi-tooling/cmd/cmd.handleTransactionReportCmdArguments(0xc000168410, 0x1, 0x1, 0xc000024044, 0x36)
	/Users/srivathsan/Documents/work2/product-mi-tooling/cmd/cmd/transactionReport.go:83 +0x206
github.com/wso2/product-mi-tooling/cmd/cmd.glob..func31(0x18ab180, 0xc000168410, 0x1, 0x1)
	/Users/srivathsan/Documents/work2/product-mi-tooling/cmd/cmd/transactionReport.go:62 +0xc3
github.com/spf13/cobra.(*Command).execute(0x18ab180, 0xc0001683e0, 0x1, 0x1, 0x18ab180, 0xc0001683e0)
	/Users/srivathsan/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0x18a9200, 0x0, 0x0, 0x13f252f)
	/Users/srivathsan/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x34a
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/srivathsan/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/wso2/product-mi-tooling/cmd/cmd.Execute()
	/Users/srivathsan/Documents/work2/product-mi-tooling/cmd/cmd/root.go:50 +0x2e
main.main()
	/Users/srivathsan/Documents/work2/product-mi-tooling/cmd/mi.go:24 +0x20
```
This PR fixes the above issue by not executing subsequent code if the user is not logged in.
Also, this PR adds `mi: Execute 'mi remote login --help' for more information` details to **mi user add**, **mi user remove** cli commands if the user is not logged in.

Related issue: https://github.com/wso2/micro-integrator/issues/1926