### PR TITLE
Improve user page errors

### DIFF
--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
@@ -64,4 +64,5 @@ public final class Constants {
 
     public static final int TOKEN_CACHE_TIMEOUT = 60;
 
+    public static final String JWKS_URI = "jwks_uri";
 }

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/commons/Utils.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/commons/Utils.java
@@ -47,7 +47,15 @@ public class Utils {
             accessToken = retrieveNewAccessToken(groupId, nodeId);
             response = HttpUtils.doGet(accessToken, url);
         } else if (isNotSuccessCode(httpSc)) {
-            throw new ManagementApiException(response.getStatusLine().getReasonPhrase(), httpSc);
+            JsonElement error = HttpUtils.getJsonResponse(response).get("Error");
+            String errorMessage = "Error occurred. Please check server logs.";
+            if (error != null) {
+                String message = error.getAsString();
+                if (null != message && !message.isEmpty()) {
+                    errorMessage = message;
+                }
+            }
+            throw new ManagementApiException(errorMessage, httpSc);
         }
         return response;
     }

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConfig.java
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConfig.java
@@ -28,13 +28,25 @@ public class SSOConfig {
     private OIDCAgentConfig oidcAgentConfig;
     private String adminGroupAttribute;
     private String allowedAdminGroups;
+    private String wellKnownEndpoint;
 
     public SSOConfig(OIDCAgentConfig oidcAgentConfig, String adminGroupAttribute,
-                     String allowedAdminGroups) {
+                     String allowedAdminGroups, String wellKnownEndpoint) {
 
         this.oidcAgentConfig = oidcAgentConfig;
         this.adminGroupAttribute = adminGroupAttribute;
         this.allowedAdminGroups = allowedAdminGroups;
+        this.wellKnownEndpoint = wellKnownEndpoint;
+    }
+
+    public String getWellKnownEndpoint() {
+
+        return wellKnownEndpoint;
+    }
+
+    public void setWellKnownEndpoint(String wellKnownEndpoint) {
+
+        this.wellKnownEndpoint = wellKnownEndpoint;
     }
 
     public OIDCAgentConfig getOidcAgentConfig() {

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConstants.java
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConstants.java
@@ -28,10 +28,14 @@ public class SSOConstants {
     public static final String TOML_SSO_ADMIN_GROUP_ATTRIBUTE = "sso.admin_group_attribute";
     public static final String TOML_SSO_ADMIN_GROUPS = "sso.admin_groups";
     public static final String TOML_SSO_JWT_ISSUER = "sso.jwt_issuer";
+    public static final String TOML_SSO_IDP_URL = "sso.idp_url";
     public static final String TOML_SSO_JWKS_ENDPOINT = "sso.jwks_endpoint";
+    public static final String TOML_SSO_WELL_KNOWN_ENDPOINT = "sso.well_known_endpoint";
     public static final String TOML_SSO_CLIENT_ID = "sso.client_id";
     public static final String TOML_SSO_CLIENT_SECRET = "sso.client_secret";
     public static final String TOML_SSO_JWKS_ALGORITHM = "sso.jwks_algorithm";
     public static final String DEFAULT_SSO_ADMIN_GROUP_ATTRIBUTE = "groups";
+
+    public static final String DEFAULT_WELL_KNOWN_ENDPOINT = "/oauth2/token/.well-known/openid-configuration";
 
 }

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/package-lock.json
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/package-lock.json
@@ -1744,6 +1744,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.60",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz",
+      "integrity": "sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/package.json
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/package.json
@@ -6,6 +6,7 @@
     "@asgardeo/auth-react": "^0.1.3",
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@monaco-editor/react": "4.0.11",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/pages/Users.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/pages/Users.js
@@ -28,6 +28,7 @@ import {makeStyles} from "@material-ui/core/styles";
 import { changeData } from '../redux/Actions';
 import Progress from '../commons/Progress';
 import HTTPClient from '../utils/HTTPClient';
+import Alert from '@material-ui/lab/Alert';
 
 export default function Users() {
     const [pageInfo] = React.useState({
@@ -41,6 +42,7 @@ export default function Users() {
     });
 
     const [users, setUsers] = React.useState(null);
+    const [error, setError] = React.useState(null);
     const classes = useStyles();
     const globalGroupId = useSelector(state => state.groupId);
     const dataSet = useSelector(state => state.data);
@@ -49,12 +51,24 @@ export default function Users() {
         HTTPClient.getUsers(globalGroupId).then(response => {
             response.data.map(data => data.details = JSON.parse(data.details));
             setUsers(response.data)
+        }).catch(error => {
+            setError(error.response.data.message)
         })
     }, [globalGroupId, dataSet]);
 
     if (AuthManager.getUser().scope !== "admin" || AuthManager.getUser().sso) {
         return (
             <Redirect to={{pathname: '/'}}/>
+        );
+    }
+
+    if (error) {
+        return (
+        <div>
+            <Alert severity="error">
+                {error}
+            </Alert>
+        </div>
         );
     }
 


### PR DESCRIPTION
## Purpose
- Get jwks endpoint using well known endpoint configs
- Show error when user page is accessed while using filebased user store

## User stories
if `jwks_endpoint` is not defined in the toml, the well known endpoint (default `<idp_url>//oauth2/token/.well-known/openid-configuration`) will be used to get the jwks endpoint.

When the user login the dashboard using the file-based user store, an error is shown in the user page as given below,
![user_error](https://user-images.githubusercontent.com/18748929/127518236-8c7e4419-7f60-4408-9fce-a219d10dbf47.png)
