### PR TITLE
Validate opaque tokens using introspection endpoint

### DIFF
--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/Bootstrap.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/Bootstrap.java
@@ -296,7 +296,7 @@ public class Bootstrap {
             }
             String adminGroups = "";
             if (parseResult.isArray(SSOConstants.TOML_SSO_ADMIN_GROUPS)) {
-                adminGroups = parseResult.getArray(SSOConstants.TOML_SSO_ADMIN_GROUPS).toString();
+                adminGroups = parseResult.getArray(SSOConstants.TOML_SSO_ADMIN_GROUPS).toJson();
             }
             if (!parseResult.isString(SSOConstants.TOML_SSO_IDP_URL)) {
                 throw new SSOConfigException("Missing value for " + SSOConstants.TOML_SSO_IDP_URL + " in SSO Configs");
@@ -306,8 +306,18 @@ public class Bootstrap {
             if (parseResult.isString(SSOConstants.TOML_SSO_WELL_KNOWN_ENDPOINT)) {
                 wellKnownEndpointPath = parseResult.getString(SSOConstants.TOML_SSO_WELL_KNOWN_ENDPOINT);
             }
+            String introspectionEndpoint = null;
+            if (parseResult.isString(SSOConstants.TOML_SSO_INTROSPECTION_ENDPOINT)) {
+                introspectionEndpoint =
+                        idpUrl + parseResult.getString(SSOConstants.TOML_SSO_INTROSPECTION_ENDPOINT);
+            }
+            String userInfoEndpoint = null;
+            if (parseResult.isString(SSOConstants.TOML_SSO_USER_INFO_ENDPOINT)) {
+                userInfoEndpoint = idpUrl + parseResult.getString(SSOConstants.TOML_SSO_USER_INFO_ENDPOINT);
+            }
             setJavaxSslTruststore(parseResult);
-            return new SSOConfig(oidcAgentConfig, adminGroupAttribute, adminGroups, idpUrl + wellKnownEndpointPath);
+            return new SSOConfig(oidcAgentConfig, adminGroupAttribute, adminGroups, idpUrl + wellKnownEndpointPath,
+                    introspectionEndpoint, userInfoEndpoint);
         }
         return null;
     }

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
@@ -51,6 +51,7 @@ public final class Constants {
     public static final String FAIL_STATUS = "fail";
 
     public static final String HEADER_VALUE_APPLICATION_JSON = "application/json";
+    public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
 
     public static final String DASHBOARD_HOME = System.getenv("DASHBOARD_HOME");
     public static final String HEARTBEAT_POOL_SIZE = System.getProperty("heartbeat_pool_size");
@@ -65,4 +66,14 @@ public final class Constants {
     public static final int TOKEN_CACHE_TIMEOUT = 60;
 
     public static final String JWKS_URI = "jwks_uri";
+    public static final String INTROSPECTION_URI = "introspection_endpoint";
+    public static final String USERINFO_URI = "userinfo_endpoint";
+
+    public static final String TOKEN = "token";
+    public static final String CLIENT_ID = "client_id";
+    public static final String CLIENT_SECRET = "client_secret";
+    public static final String ACTIVE = "active";
+    public static final String SCOPE = "scope";
+    public static final String ADMIN = "admin";
+
 }

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthenticationFilter.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthenticationFilter.java
@@ -18,15 +18,12 @@
 
 package org.wso2.ei.dashboard.core.commons.auth;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.wso2.ei.dashboard.core.rest.annotation.Secured;
 import org.wso2.micro.integrator.dashboard.utils.SSOConfig;
 import org.wso2.micro.integrator.dashboard.utils.SSOConstants;
 
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,11 +47,8 @@ import javax.ws.rs.ext.Provider;
 public class AuthenticationFilter implements ContainerRequestFilter {
 
     private static final String AUTHENTICATION_SCHEME = "Bearer";
-    private static final Base64.Decoder decoder = Base64.getUrlDecoder();
-    private static final List<String> adminOnlyPaths = Arrays.asList("groups/mi_test/log-configs",
-                                                                     "groups/mi_test/users");
-
-    private static final Logger logger = LogManager.getLogger(AuthenticationFilter.class);
+    private static final List<String> adminOnlyPaths = Arrays.asList("/log-configs",
+                                                                     "/users");
 
     @Context
     private HttpServletRequest servletRequest;
@@ -88,7 +82,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     private static boolean isAdminResource(ContainerRequestContext requestContext) {
 
         String path = ((ContainerRequest) requestContext).getPath(false);
-        return adminOnlyPaths.contains(path);
+        String resource = path.substring(path.lastIndexOf("/"));
+        return adminOnlyPaths.contains(resource);
     }
 
     private static SecurityHandler getSecurityHandler(String token) {

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/InMemorySecurityHandler.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/InMemorySecurityHandler.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.auth;
+
+import com.google.gson.JsonElement;
+import org.wso2.ei.dashboard.core.commons.Constants;
+import org.wso2.ei.dashboard.core.commons.utils.TokenUtils;
+import org.wso2.micro.integrator.dashboard.utils.SSOConfig;
+
+/**
+ * This class implements SecurityHandler to implement the authentication logic for a In memory user store for
+ * dashboard api.
+ */
+public class InMemorySecurityHandler implements SecurityHandler {
+
+    @Override
+    public boolean isAuthenticated(SSOConfig ssoConfig, String token) {
+
+        return TokenCache.getInstance().getToken(token) != null;
+    }
+
+    @Override
+    public boolean isAuthorized(SSOConfig ssoConfig, String token) {
+
+        JsonElement jsonElementPayload = TokenUtils.getParsedToken(token);
+        JsonElement scopeElement = jsonElementPayload.getAsJsonObject().get(Constants.SCOPE);
+        if (scopeElement != null) {
+            String scope = scopeElement.getAsString();
+            return scope.equals(Constants.ADMIN);
+        }
+        return false;
+    }
+}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/JWTSecurityHandler.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/JWTSecurityHandler.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.auth;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import io.asgardeo.java.oidc.sdk.exception.SSOAgentServerException;
+import io.asgardeo.java.oidc.sdk.validators.IDTokenValidator;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.ei.dashboard.core.commons.Constants;
+import org.wso2.ei.dashboard.core.commons.utils.HttpUtils;
+import org.wso2.ei.dashboard.core.commons.utils.TokenUtils;
+import org.wso2.ei.dashboard.core.exception.DashboardServerException;
+import org.wso2.micro.integrator.dashboard.utils.SSOConfig;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+
+/**
+ * This class implements SecurityHandler to implement the authentication logic for a JWT self contained token.
+ */
+public class JWTSecurityHandler implements SecurityHandler {
+
+    private static final Logger logger = LogManager.getLogger(JWTSecurityHandler.class);
+
+    @Override
+    public boolean isAuthenticated(SSOConfig config, String token) {
+
+        JWT idTokenJWT = null;
+        try {
+            idTokenJWT = JWTParser.parse(token);
+            if (config.getOidcAgentConfig().getJwksEndpoint() == null) {
+                config.getOidcAgentConfig()
+                        .setJwksEndpoint(getJWKSEndpointFromWellKnownEndpoint(config.getWellKnownEndpoint()));
+            }
+            IDTokenValidator validator = new IDTokenValidator(config.getOidcAgentConfig(), idTokenJWT);
+            validator.validate(null);
+            return true;
+        } catch (DashboardServerException | ParseException | SSOAgentServerException e) {
+            if (logger.isDebugEnabled()) {
+                logger.error("Error validating the access token", e);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isAuthorized(SSOConfig ssoConfig, String token) {
+
+        JsonElement jsonElementPayload = TokenUtils.getParsedToken(token);
+        return isUserInAdminGroup(jsonElementPayload, ssoConfig);
+    }
+
+    private boolean isUserInAdminGroup(JsonElement tokenPayload, SSOConfig config) {
+
+        JsonArray groupElement = tokenPayload.getAsJsonObject().getAsJsonArray(config.getAdminGroupAttribute());
+        for (JsonElement group : groupElement) {
+            if (config.getAllowedAdminGroups().contains(group.getAsString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private URI getJWKSEndpointFromWellKnownEndpoint(String wellKnownEndpointPath) {
+
+        HttpGet httpGet = new HttpGet(wellKnownEndpointPath);
+        CloseableHttpResponse httpResponse = HttpUtils.doGet(httpGet);
+
+        int httpSc = httpResponse.getStatusLine().getStatusCode();
+
+        if (httpSc == HttpStatus.SC_OK) {
+            try {
+                return new URI(HttpUtils.getJsonResponse(httpResponse).get(Constants.JWKS_URI).getAsString());
+            } catch (URISyntaxException e) {
+                throw new DashboardServerException("Invalid url for " + Constants.JWKS_URI, e);
+            }
+        }
+        throw new DashboardServerException("Cannot find " + Constants.JWKS_URI + " in well known endpoint response. " +
+                httpResponse.getStatusLine().getReasonPhrase());
+    }
+}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/OpaqueTokenSecurityHandler.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/OpaqueTokenSecurityHandler.java
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.auth;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.ei.dashboard.core.commons.Constants;
+import org.wso2.ei.dashboard.core.commons.utils.HttpUtils;
+import org.wso2.ei.dashboard.core.exception.DashboardServerException;
+import org.wso2.micro.integrator.dashboard.utils.SSOConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.wso2.ei.dashboard.core.commons.Constants.TOKEN_CACHE_TIMEOUT;
+
+/**
+ * This class implements SecurityHandler to implement the authentication logic for a Opaque token.
+ */
+public class OpaqueTokenSecurityHandler implements SecurityHandler {
+
+    private static final Logger logger = LogManager.getLogger(OpaqueTokenSecurityHandler.class);
+    private static final Cache<String, Boolean> adminClaimMap =
+            CacheBuilder.newBuilder().expireAfterWrite(TOKEN_CACHE_TIMEOUT, TimeUnit.MINUTES).build();
+
+    @Override
+    public boolean isAuthenticated(SSOConfig config, String token) {
+
+        if (config.getIntrospectionEndpoint() == null) {
+            config.setIntrospectionEndpoint(
+                    getIntrospectionEndpointFromWellKnownEndpoint(config.getWellKnownEndpoint()));
+        }
+
+        Map<String, String> introspectionRequestBody = new HashMap<>();
+        introspectionRequestBody.put(Constants.TOKEN, token);
+        introspectionRequestBody.put(Constants.CLIENT_ID, config.getOidcAgentConfig().getConsumerKey().getValue());
+        introspectionRequestBody
+                .put(Constants.CLIENT_SECRET, config.getOidcAgentConfig().getConsumerSecret().getValue());
+
+        CloseableHttpResponse httpResponse =
+                HttpUtils.doPost(config.getIntrospectionEndpoint(), introspectionRequestBody);
+
+        int httpSc = httpResponse.getStatusLine().getStatusCode();
+
+        if (httpSc == HttpStatus.SC_OK) {
+            return HttpUtils.getJsonResponse(httpResponse).get(Constants.ACTIVE).getAsBoolean();
+        }
+        if (logger.isDebugEnabled()) {
+            logger.error("Error validating the token using introspection endpoint. ",
+                    httpResponse.getStatusLine().getReasonPhrase());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isAuthorized(SSOConfig ssoConfig, String token) {
+
+        return validateWithCache(token) || validateAdminWithUserInfoEndpoint(ssoConfig, token);
+    }
+
+    private boolean validateWithCache(String token) {
+
+        if (adminClaimMap.getIfPresent(token) != null) {
+            return adminClaimMap.getIfPresent(token);
+        }
+        return false;
+    }
+
+    private boolean validateAdminWithUserInfoEndpoint(SSOConfig config, String token) {
+
+        if (config.getUserInfoEndpoint() == null) {
+            config.setUserInfoEndpoint(
+                    getUserInfoEndpointFromWellKnownEndpoint(config.getWellKnownEndpoint()));
+        }
+
+        CloseableHttpResponse httpResponse =
+                HttpUtils.doGet(token, config.getUserInfoEndpoint());
+
+        int httpSc = httpResponse.getStatusLine().getStatusCode();
+
+        if (httpSc == HttpStatus.SC_OK) {
+            JsonArray groupElement =
+                    HttpUtils.getJsonResponse(httpResponse).get(config.getAdminGroupAttribute()).getAsJsonArray();
+            for (JsonElement group : groupElement) {
+                if (config.getAllowedAdminGroups().contains(group.getAsString())) {
+                    adminClaimMap.put(token, true);
+                    return true;
+                }
+            }
+            adminClaimMap.put(token, false);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.error("Error validating the token using userInfo endpoint. ",
+                    httpResponse.getStatusLine().getReasonPhrase());
+        }
+        return false;
+    }
+
+    private String getUserInfoEndpointFromWellKnownEndpoint(String wellKnownEndpoint) {
+
+        HttpGet httpGet = new HttpGet(wellKnownEndpoint);
+        CloseableHttpResponse httpResponse = HttpUtils.doGet(httpGet);
+
+        int httpSc = httpResponse.getStatusLine().getStatusCode();
+
+        if (httpSc == HttpStatus.SC_OK) {
+            JsonObject jsonResponse = HttpUtils.getJsonResponse(httpResponse);
+            if (jsonResponse.has(Constants.USERINFO_URI)) {
+                return jsonResponse.get(Constants.USERINFO_URI).getAsString();
+            }
+        }
+        throw new DashboardServerException("Cannot find " + Constants.USERINFO_URI + " in well known endpoint " +
+                "response. " +
+                httpResponse.getStatusLine().getReasonPhrase());
+    }
+
+    private String getIntrospectionEndpointFromWellKnownEndpoint(String wellKnownEndpoint) {
+
+        HttpGet httpGet = new HttpGet(wellKnownEndpoint);
+        CloseableHttpResponse httpResponse = HttpUtils.doGet(httpGet);
+
+        int httpSc = httpResponse.getStatusLine().getStatusCode();
+
+        if (httpSc == HttpStatus.SC_OK) {
+            JsonObject jsonResponse = HttpUtils.getJsonResponse(httpResponse);
+            if (jsonResponse.has(Constants.INTROSPECTION_URI)) {
+                return jsonResponse.get(Constants.INTROSPECTION_URI).getAsString();
+            }
+        }
+        throw new DashboardServerException("Cannot find " + Constants.INTROSPECTION_URI + " in well known endpoint " +
+                "response. " +
+                httpResponse.getStatusLine().getReasonPhrase());
+    }
+}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/SecurityHandler.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/SecurityHandler.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.auth;
+
+import org.wso2.micro.integrator.dashboard.utils.SSOConfig;
+
+/**
+ * This class provides an interface for all security handlers.
+ */
+public interface SecurityHandler {
+
+    /**
+     * Executes the authentication logic relevant to the handler.
+     *
+     * @param ssoConfig SSOConfig
+     * @param token     authorization token
+     * @return Boolean authenticated
+     */
+    boolean isAuthenticated(SSOConfig ssoConfig, String token);
+
+    /**
+     * Executes the authorization logic relevant to the handler.
+     *
+     * @param ssoConfig SSOConfig
+     * @param token     authorization token
+     * @return Boolean authenticated
+     */
+    boolean isAuthorized(SSOConfig ssoConfig, String token);
+
+}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/utils/HttpUtils.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/utils/HttpUtils.java
@@ -49,6 +49,8 @@ import org.wso2.ei.dashboard.core.exception.DashboardServerException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.Response;
 
@@ -86,6 +88,24 @@ public class HttpUtils {
 
         httpPost.setHeader("Authorization", authHeader);
         httpPost.setHeader("content-type", Constants.HEADER_VALUE_APPLICATION_JSON);
+        try {
+            StringEntity entity = new StringEntity(payload.toString());
+            httpPost.setEntity(entity);
+            return doPost(httpPost);
+        } catch (UnsupportedEncodingException e) {
+            throw new DashboardServerException("Error occurred while creating http post request.", e);
+        }
+    }
+
+    public static CloseableHttpResponse doPost(String url, Map<String, String> params) {
+        final HttpPost httpPost = new HttpPost(url);
+
+        StringBuilder payload = new StringBuilder();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            payload.append(entry.getKey()).append("=").append(entry.getValue()).append("&");
+        }
+
+        httpPost.setHeader("Content-type", Constants.APPLICATION_X_WWW_FORM_URLENCODED);
         try {
             StringEntity entity = new StringEntity(payload.toString());
             httpPost.setEntity(entity);

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/utils/TokenUtils.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/utils/TokenUtils.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.utils;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import java.util.Base64;
+
+/**
+ * Utilities to handle access tokens.
+ */
+public class TokenUtils {
+
+    private static final Base64.Decoder decoder = Base64.getUrlDecoder();
+
+    public static JsonElement getParsedToken(String token) {
+
+        String[] parts = token.split("\\.");
+        String payloadJson = new String(decoder.decode(parts[1]));
+        return JsonParser.parseString(payloadJson);
+    }
+}

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConfig.java
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConfig.java
@@ -29,14 +29,19 @@ public class SSOConfig {
     private String adminGroupAttribute;
     private String allowedAdminGroups;
     private String wellKnownEndpoint;
+    private String introspectionEndpoint;
+    private String userInfoEndpoint;
 
     public SSOConfig(OIDCAgentConfig oidcAgentConfig, String adminGroupAttribute,
-                     String allowedAdminGroups, String wellKnownEndpoint) {
+                     String allowedAdminGroups, String wellKnownEndpoint, String introspectionEndpoint,
+                     String userInfoEndpoint) {
 
         this.oidcAgentConfig = oidcAgentConfig;
         this.adminGroupAttribute = adminGroupAttribute;
         this.allowedAdminGroups = allowedAdminGroups;
         this.wellKnownEndpoint = wellKnownEndpoint;
+        this.introspectionEndpoint = introspectionEndpoint;
+        this.userInfoEndpoint = userInfoEndpoint;
     }
 
     public String getWellKnownEndpoint() {
@@ -77,5 +82,25 @@ public class SSOConfig {
     public void setAllowedAdminGroups(String allowedAdminGroups) {
 
         this.allowedAdminGroups = allowedAdminGroups;
+    }
+
+    public String getIntrospectionEndpoint() {
+
+        return introspectionEndpoint;
+    }
+
+    public void setIntrospectionEndpoint(String introspectionEndpoint) {
+
+        this.introspectionEndpoint = introspectionEndpoint;
+    }
+
+    public String getUserInfoEndpoint() {
+
+        return userInfoEndpoint;
+    }
+
+    public void setUserInfoEndpoint(String userInfoEndpoint) {
+
+        this.userInfoEndpoint = userInfoEndpoint;
     }
 }

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConstants.java
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.utils/src/main/java/org/wso2/micro/integrator/dashboard/utils/SSOConstants.java
@@ -31,6 +31,8 @@ public class SSOConstants {
     public static final String TOML_SSO_IDP_URL = "sso.idp_url";
     public static final String TOML_SSO_JWKS_ENDPOINT = "sso.jwks_endpoint";
     public static final String TOML_SSO_WELL_KNOWN_ENDPOINT = "sso.well_known_endpoint";
+    public static final String TOML_SSO_INTROSPECTION_ENDPOINT = "sso.introspection_endpoint";
+    public static final String TOML_SSO_USER_INFO_ENDPOINT = "sso.user_info_endpoint";
     public static final String TOML_SSO_CLIENT_ID = "sso.client_id";
     public static final String TOML_SSO_CLIENT_SECRET = "sso.client_secret";
     public static final String TOML_SSO_JWKS_ALGORITHM = "sso.jwks_algorithm";

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Login.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Login.js
@@ -176,7 +176,7 @@ function Login(props){
                             variant="contained"
                             color="primary"
                             onClick={ () => {
-                                signIn();
+                                signIn(window.sso.authorizationRequestParams);
                             } }>
                             Sign In with SSO
                         </Button>

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/sso.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/sso.js
@@ -43,7 +43,8 @@ function SSO() {
                         scope = "admin"
                     }
                 }
-                AuthManager.setUser({username: decodedIDToken.sub, scope: scope, sso: true}, true);
+                var userNameAttribute = window.sso.usernameAttribute
+                AuthManager.setUser({username: decodedIDToken[userNameAttribute], scope: scope, sso: true}, true);
                 history.push("/");
             };
             getData();

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/sso.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/sso.js
@@ -28,7 +28,7 @@ function SSO() {
     const history = useHistory();
 
     useEffect(() => {
-        signIn()
+        signIn(window.sso.authorizationRequestParams)
     },[])
 
     useEffect(() => {

--- a/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/default.json
+++ b/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/default.json
@@ -1,4 +1,5 @@
 {
 	"sso.enable": false,
-	"sso.storage": "webWorker"
+	"sso.storage": "webWorker",
+	"sso.user_name_attribute" : "sub"
 }

--- a/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/config.js.j2
+++ b/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/config.js.j2
@@ -55,5 +55,12 @@ window.sso = {
         {% endif %}
     },
     adminGroupAttribute: "{{sso.admin_group_attribute}}",
-    allowedAdminGroups: [{% for group in sso.admin_groups %}"{{group}}"{% if loop.index < sso.admin_groups|length %},{% endif %}{% endfor %}]
+    allowedAdminGroups: [{% for group in sso.admin_groups %}"{{group}}"{% if loop.index < sso.admin_groups|length %},{% endif %}{% endfor %}],
+    {% if sso.authorization_request.params is defined %}
+     authorizationRequestParams: {
+        {% for param in sso.authorization_request.params %}
+        {{param.key}}:"{{param.value}}"{% if loop.index < sso.authorization_request.params|length %},{% endif %}
+        {% endfor %}
+     }
+    {% endif %}
 };

--- a/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/config.js.j2
+++ b/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/config.js.j2
@@ -54,6 +54,7 @@ window.sso = {
         scope: [{% for value in sso.scope %}"{{value}}"{% if loop.index < sso.scope|length %},{% endif %}{% endfor %}],
         {% endif %}
     },
+    usernameAttribute: "{{sso.user_name_attribute}}",
     adminGroupAttribute: "{{sso.admin_group_attribute}}",
     allowedAdminGroups: [{% for group in sso.admin_groups %}"{{group}}"{% if loop.index < sso.admin_groups|length %},{% endif %}{% endfor %}],
     {% if sso.authorization_request.params is defined %}


### PR DESCRIPTION
## Purpose
- If opaque tokens are used as access token, the introspection endpoint is used to validate the token.
- Use the userInfo endpoint to authorize the user when accessing admin resources.
- Add option to define username attribute