### PR TITLE
Improve dashboard security

### DIFF
--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
@@ -64,12 +64,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import javax.servlet.DispatcherType;
 
 /**
  * This class starting up the jetty server on the port as defined in deployment.toml file.
@@ -230,6 +233,7 @@ public class DashboardServer {
         wwwApp.setContextPath("/");
         wwwApp.setResourceBase(dashboardHome + File.separator + SERVER_DIR + File.separator + WWW_DIR);
         wwwApp.setParentLoaderPriority(true);
+        wwwApp.addFilter(SecurityHeaderFilter.class, "/*", EnumSet.of(DispatcherType.INCLUDE, DispatcherType.REQUEST));
         wwwApp.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
         handlers.addHandler(wwwApp);
         server.setHandler(handlers);

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
@@ -230,6 +230,7 @@ public class DashboardServer {
         wwwApp.setContextPath("/");
         wwwApp.setResourceBase(dashboardHome + File.separator + SERVER_DIR + File.separator + WWW_DIR);
         wwwApp.setParentLoaderPriority(true);
+        wwwApp.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
         handlers.addHandler(wwwApp);
         server.setHandler(handlers);
     }

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/SecurityHeaderFilter.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/SecurityHeaderFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ei.dashboard.bootstrap;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This class is responsible for adding the security headers for the HTTP responses.
+ */
+public class SecurityHeaderFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        final HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+        httpResponse.addHeader("Content-Security-Policy", "frame-ancestors 'none'");
+        httpResponse.addHeader("X-Frame-Options", "DENY");
+        httpResponse.addHeader("X-Content-Type-Options", "nosniff");
+        httpResponse.addHeader("Referrer-Policy", "same-origin");
+        filterChain.doFilter(servletRequest, servletResponse);
+
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
@@ -78,4 +78,6 @@ public final class Constants {
     public static final String SCOPE = "scope";
     public static final String ADMIN = "admin";
 
+    public static final String JWT_COOKIE = "JWT_TOKEN";
+    public static final String COOKIE_HEADER = "SET-COOKIE";
 }

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/LogoutApi.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/LogoutApi.java
@@ -31,11 +31,11 @@ import org.wso2.ei.dashboard.core.rest.delegates.auth.LogoutDelegate;
 import org.wso2.ei.dashboard.core.rest.model.Ack;
 import org.wso2.ei.dashboard.core.rest.model.Error;
 
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.Response;
 
 @Path("/logout")
@@ -52,13 +52,11 @@ public class LogoutApi {
         @ApiResponse(responseCode = "200", description = "Logout successful", content = @Content(schema = @Schema(implementation = Ack.class))),
         @ApiResponse(responseCode = "200", description = "Unexpected error", content = @Content(schema = @Schema(implementation = Error.class)))
     })
-    public Response receiveLogout(@Context HttpHeaders httpHeaders) {
-        String authorizationHeader = httpHeaders.getHeaderString("Authorization");
-        if (authorizationHeader != null) {
+    public Response receiveLogout(@CookieParam(Constants.JWT_COOKIE) Cookie cookie) {
+        if (cookie != null) {
             String token = Constants.EMPTY_STRING;
-            String[] splitResult = authorizationHeader.split(" ");
-            if (splitResult.length > 1) {
-                token = splitResult[1];
+            if (!cookie.getValue().isEmpty()) {
+                token = cookie.getValue();
             }
             return logoutDelegate.logoutUser(token);
         }

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/auth/LogoutDelegate.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/auth/LogoutDelegate.java
@@ -19,9 +19,12 @@
 
 package org.wso2.ei.dashboard.core.rest.delegates.auth;
 
+import org.wso2.ei.dashboard.core.commons.Constants;
 import org.wso2.ei.dashboard.core.commons.auth.TokenCache;
 
 import javax.ws.rs.core.Response;
+
+import static org.wso2.ei.dashboard.core.rest.delegates.auth.LoginDelegate.getTokenCookieHeader;
 
 /**
  * Manages login received to the dashboard.
@@ -29,10 +32,10 @@ import javax.ws.rs.core.Response;
 public class LogoutDelegate {
 
     public Response logoutUser(String accessToken) {
-        if (accessToken.isEmpty()) {
+        if (!accessToken.isEmpty()) {
             removeTokenFromCache(accessToken);
         }
-        return Response.ok().build();
+        return Response.ok().header(Constants.COOKIE_HEADER, getTokenCookieHeader(null, 0)).build();
     }
 
     private void removeTokenFromCache(String accessToken) {

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/AuthManager.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/AuthManager.js
@@ -19,7 +19,6 @@
 import {Constants} from './Constants';
 import qs from 'qs'
 import axios from 'axios'
-import jwt_decode from "jwt-decode";
 
 export default class AuthManager {
 
@@ -45,14 +44,7 @@ export default class AuthManager {
                 }
             })
             .then((response) => {
-                var accessToken = response.data
-                const decodedToken = jwt_decode(accessToken);
-                let scope = "default"
-                if (decodedToken !== undefined) {
-                    scope = decodedToken.scope;
-                }
-                AuthManager.setUser({username: username, scope: scope, sso: false}, isSecure);
-                AuthManager.setCookie(Constants.JWT_TOKEN_COOKIE, accessToken, 3600, window.contextPath, isSecure);
+                AuthManager.setUser(response.data, isSecure);
                 resolve();
             })
             .catch(error => {
@@ -95,7 +87,6 @@ export default class AuthManager {
      */
     static discardSession() {
         AuthManager.deleteCookie(Constants.SESSION_USER_COOKIE);
-        AuthManager.deleteCookie(Constants.JWT_TOKEN_COOKIE);
         window.localStorage.clear();
     }
 
@@ -126,13 +117,9 @@ export default class AuthManager {
      */
     static logout() {
         return new Promise((resolve, reject) => {
-            var token = AuthManager.getCookie(Constants.JWT_TOKEN_COOKIE)
             axios({
                 method: 'get',
-                url: AuthManager.getBasePath().concat('/logout'),
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                }
+                url: AuthManager.getBasePath().concat('/logout')
             })
             .then(() => {
                 AuthManager.discardSession();

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Interceptor.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Interceptor.js
@@ -23,7 +23,7 @@ import AuthManager from "./AuthManager";
 
 export default function interceptor(logout){
     axios.interceptors.response.use(undefined, function axiosRetryInterceptor(error){
-        if(error.response.status === 401 ){
+        if(AuthManager.isLoggedIn() && error.response.status === 401 ){
             AuthManager.logout()
                 .then(() =>{
                    logout();

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Interceptor.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Interceptor.js
@@ -20,19 +20,8 @@
 
 import axios from "axios";
 import AuthManager from "./AuthManager";
-import {Constants} from "./Constants";
 
 export default function interceptor(logout){
-    axios.interceptors.request.use(
-        request => {
-            request.headers['Authorization'] = "Bearer " + AuthManager.getCookie(Constants.JWT_TOKEN_COOKIE);
-            return request;
-        },
-        error => {
-            return Promise.reject(error);
-        }
-    );
-
     axios.interceptors.response.use(undefined, function axiosRetryInterceptor(error){
         if(error.response.status === 401 ){
             AuthManager.logout()
@@ -42,5 +31,4 @@ export default function interceptor(logout){
         }
         return Promise.reject(error);
     })
-
 }

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Login.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Login.js
@@ -136,7 +136,7 @@ function Login(props){
                             id="username"
                             label="Username"
                             name="username"
-                            autoComplete="on"
+                            autoComplete="off"
                             value={userName}
                             onChange={(e) => { setUserName(e.target.value)}}
                             autoFocus
@@ -151,7 +151,7 @@ function Login(props){
                             type="password"
                             id="password"
                             value={password}
-                            autoComplete="on"
+                            autoComplete="off"
                             onChange={(e) => {setPassword(e.target.value)}}
                         />
                         <FormControlLabel


### PR DESCRIPTION
## Purpose
1. Use HTTPOnly cookie to store the access token
2. Deny jetty directory access
3. Add security headers
4. Set autocomplete=off for login page