### PR TITLE
Add health check for MI Dashboard

### DIFF
--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/HealthzApi.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/HealthzApi.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+
+package org.wso2.ei.dashboard.core.rest.api;
+
+import org.wso2.ei.dashboard.core.rest.model.Error;
+import org.wso2.ei.dashboard.core.rest.model.Healthz;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.util.Map;
+import java.util.List;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+
+@Path("/healthz")
+
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaJAXRSSpecServerCodegen", date = "2022-06-09T13:17:37.553+05:30[Asia/Colombo]")
+public class HealthzApi {
+
+    @GET
+    @Produces({ "application/json" })
+    @Operation(summary = "Get health check for the dashboard", description = "", tags={ "healthz" })
+    @ApiResponses(value = { 
+        @ApiResponse(responseCode = "200", description = "Health check status", content = @Content(schema = @Schema(implementation = Healthz.class))),
+        @ApiResponse(responseCode = "500", description = "Unexpected error", content = @Content(schema = @Schema(implementation = Error.class)))
+    })
+    public Response retrieveHealth() {
+        Healthz healthz = new Healthz();
+        healthz.setStatus("ready");
+        Response.ResponseBuilder responseBuilder = Response.ok().entity(healthz);
+        return responseBuilder.build();
+    }}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/Healthz.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/Healthz.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+
+package org.wso2.ei.dashboard.core.rest.model;
+
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class Healthz   {
+  private @Valid String status = null;
+
+  /**
+   **/
+  public Healthz status(String status) {
+    this.status = status;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("status")
+
+  public String getStatus() {
+    return status;
+  }
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Healthz healthz = (Healthz) o;
+    return Objects.equals(status, healthz.status);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Healthz {\n");
+    
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/resources/swagger.yaml
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/resources/swagger.yaml
@@ -1261,6 +1261,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /healthz:
+    get:
+      tags:
+        - "healthz"
+      summary: "Get health check for the dashboard"
+      operationId: "RetrieveHealth"
+      responses:
+        200:
+          description: "Health check status"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/healthz'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   schemas:
@@ -1488,6 +1507,11 @@ components:
       type: object
       properties:
         configuration:
+          type: string
+    healthz:
+      type: object
+      properties:
+        status:
           type: string
     LocalEntryValue:
       type: object

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/swagger.json
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/swagger.json
@@ -1918,6 +1918,35 @@
           }
         }
       }
+    },
+    "/healthz" : {
+      "get" : {
+        "tags" : [ "healthz" ],
+        "summary" : "Get health check for the dashboard",
+        "operationId" : "RetrieveHealth",
+        "responses" : {
+          "200" : {
+            "description" : "Health check status",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/healthz"
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components" : {
@@ -2160,6 +2189,14 @@
         "type" : "object",
         "properties" : {
           "configuration" : {
+            "type" : "string"
+          }
+        }
+      },
+      "healthz" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
             "type" : "string"
           }
         }


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/171
Health API can be accessed with the URL https://localhost:9743/dashboard/api/healthz and the following is sample response from the MI Dashboard:
```
{"status":"ready"}
```