### PR TITLE
Fix an issue in overriding SSO authentication endpoint

### DIFF
--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/package.json
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@asgardeo/auth-react": "^0.1.3",
+    "@asgardeo/auth-react": "^2.0.4",
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/server/www/conf/config.js.j2
+++ b/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/server/www/conf/config.js.j2
@@ -44,6 +44,9 @@ window.sso = {
             {% if sso.end_session_endpoint is defined %}
             endSessionEndpoint: "{{sso.end_session_endpoint}}",
             {% endif %}
+            {% if sso.jwt_issuer is defined %}
+            issuer: "{{sso.jwt_issuer}}",
+            {% endif %}
         },
         {% endif %}
     	{% if sso.enable_PKCE is defined %}


### PR DESCRIPTION
## Purpose
When configuring SSO, the default authentication endpoint cannot be overridden by providing a custom authentication URL.

Resolves https://github.com/wso2/micro-integrator/issues/3237

## Approach
This issue is due to a limitation in the underlying `asgardeo/auth-react` library version. In the latest version of the same library, the issue is fixed. Therefore this fix upgrades the library to the latest version and adds additional configuration as well.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes