### PR TITLE
Resolves encoding users with spaces

### DIFF
--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/delegates/UsersDelegate.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/delegates/UsersDelegate.java
@@ -227,7 +227,7 @@ public class UsersDelegate {
 
     private static String urlEncode(String userId) {
         try {
-            return URLEncoder.encode(userId, "UTF-8");
+            return URLEncoder.encode(userId, "UTF-8").replace("+", "%20");
         } catch (UnsupportedEncodingException e) {
             log.error("Error occurred while encoding user id " + userId, e);
             return userId;


### PR DESCRIPTION
## Overview
When a user is added with spaces(one or more) mi-dashboard fails to fetch the users and gives and internal server error response. This occurs due to conflicting encoding in java and javascript. Java encodes spaces as "+" while javascript encodes spaces as "%20". This PR resolves it by encoding the space as "%20".

## Related issue
[api-manager#1427](https://github.com/wso2/api-manager/issues/1427)

