### PR TITLE
Make non-admin user read-only with a config

### DIFF
--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
@@ -24,6 +24,7 @@ import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import io.asgardeo.java.oidc.sdk.config.model.OIDCAgentConfig;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.server.Connector;
@@ -120,6 +121,9 @@ public class DashboardServer {
     private static SSOConfig ssoConfig;
     private static Thread shutdownHook;
     private static SecretResolver secretResolver = new SecretResolver();
+    private static boolean makeNonAdminUsersReadOnly;
+    private static final String TOML_MAKE_NON_ADMIN_USERS_READ_ONLY = "user_access.make_non_admin_users_read_only";
+    private static final String MAKE_NON_ADMIN_USERS_READ_ONLY = "make_non_admin_users_read_only";
 
     private static final Logger logger = LogManager.getLogger(DashboardServer.class);
 
@@ -312,6 +316,15 @@ public class DashboardServer {
             }
             properties.put(IS_USER_STORE_FILE_BASED, String.valueOf(isFileBased));
         }
+
+        String makeNonAdminUsersReadOnlySystemValue = System.getProperty(MAKE_NON_ADMIN_USERS_READ_ONLY);
+        if (StringUtils.isNotEmpty(makeNonAdminUsersReadOnlySystemValue)) {
+            makeNonAdminUsersReadOnly = Boolean.parseBoolean(makeNonAdminUsersReadOnlySystemValue);
+        } else {
+            makeNonAdminUsersReadOnly = Boolean.parseBoolean(
+                    String.valueOf(parsedConfigs.get(TOML_MAKE_NON_ADMIN_USERS_READ_ONLY)));
+        }
+        properties.put(MAKE_NON_ADMIN_USERS_READ_ONLY, String.valueOf(makeNonAdminUsersReadOnly));
 
         System.setProperties(properties);
     }

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/AuthManager.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/AuthManager.js
@@ -172,4 +172,33 @@ export default class AuthManager {
     static getBasePath() {
         return window.location.protocol+'//'+window.location.hostname+(window.location.port ? ':'+window.location.port: '') + "/dashboard/api";
     }
+    
+    /**
+     * Check whether the user is an admin user.
+     * @returns {boolean} true if the user is an admin user
+     */
+    static isAdminUser() {
+        const userName = AuthManager.getUser();
+        return userName?.scope === "admin";
+    }
+
+    /**
+     * Check if non-admin users are read-only based on a config.
+     * @returns {boolean} true if non-admin users are read-only
+     */
+    static isNonAdminUserReadOnly() {
+        const makeNonAdminUsersReadOnly = window.userAccess.makeNonAdminUsersReadOnly;
+        return makeNonAdminUsersReadOnly === true;
+    }
+
+    /**
+     * Check if the current user has edit permissions.
+     * All the admin users can edit and if the 'isNonAdminUserReadOnly' is false,
+     * non-admin users also can edit
+     * @returns {boolean} true if the user has edit permissions
+     */
+    static hasEditPermission() {
+        return AuthManager.isAdminUser() || !AuthManager.isNonAdminUserReadOnly();
+    }
+
 }

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/TableRowCreator.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/TableRowCreator.js
@@ -234,6 +234,7 @@ function SwitchStatusCell(props) {
     const { pageId, artifactName, nodeId, status, retrieveData} = props;
     var isActive = status;
     const globalGroupId = useSelector(state => state.groupId);
+    const hasEditPermission = AuthManager.hasEditPermission();
 
     const changeState = () => {
         isActive = !isActive
@@ -254,7 +255,7 @@ function SwitchStatusCell(props) {
         });
     }
 
-    return <tr><td><Switch checked={isActive} onChange={changeState} height={16} width={36} /></td></tr>
+    return <tr><td><Switch checked={isActive} onChange={changeState} height={16} width={36} disabled={!hasEditPermission}/></td></tr>
 }
 
 function LogConfigLevelDropDown(props) {

--- a/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/sideDrawers/commons/TracingRow.js
+++ b/monitoring-dashboard/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/sideDrawers/commons/TracingRow.js
@@ -23,10 +23,12 @@ import { TableCell, TableRow } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import Switch from "react-switch";
 import HTTPClient from '../../../utils/HTTPClient';
+import AuthManager from "../../../auth/AuthManager";
 
 export default function TracingRow(props) {
     const {pageId, artifactName, nodeId, tracing, retrieveUpdatedArtifact} = props;
     var isTracingEnabled = false;
+    const hasEditPermission = AuthManager.hasEditPermission();
 
     if(tracing === 'enabled') {
         isTracingEnabled = true;
@@ -63,7 +65,7 @@ export default function TracingRow(props) {
                 <TableCell>Tracing</TableCell>
                 <TableCell>
                     <label>
-                        <Switch checked={tracingState} onChange={changeTracingStatus} height={16} width={36} />
+                        <Switch checked={tracingState} onChange={changeTracingStatus} height={16} width={36} disabled={!hasEditPermission} />
                     </label>
                 </TableCell>
             </TableRow>

--- a/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/server/www/conf/config.js.j2
+++ b/monitoring-dashboard/distribution/src/main/resources/conf/config-parser/templates/server/www/conf/config.js.j2
@@ -76,3 +76,8 @@ window.sso = {
 window.userStore = {
     type : "{{user_store.type | default('file_based') }}"
 };
+
+window.userAccess = {
+    makeNonAdminUsersReadOnly: {{ user_access.make_non_admin_users_read_only | default(false) }}
+};
+

--- a/monitoring-dashboard/distribution/src/main/resources/conf/deployment.toml
+++ b/monitoring-dashboard/distribution/src/main/resources/conf/deployment.toml
@@ -29,3 +29,6 @@ password = "wso2carbon"
 #user.name = "admin"
 #user.password = "admin"
 #user.is_admin = true
+
+[user_access]
+make_non_admin_users_read_only = false


### PR DESCRIPTION
## Purpose
> Make the non-admin user read-only in MI dashboard when the following config is added to the deployment.toml
```
[user_access]
make_non_admin_users_read_only = true
```
Fixes: https://github.com/wso2/micro-integrator/issues/3557