### PR TITLE
[ICP-1.0.0] Fix issues with client trust store and user management

### DIFF
--- a/monitoring-dashboard/components/org.wso2.dashboard.security.user.core/src/main/java/org/wso2/dashboard/security/user/core/common/AbstractUserStoreManager.java
+++ b/monitoring-dashboard/components/org.wso2.dashboard.security.user.core/src/main/java/org/wso2/dashboard/security/user/core/common/AbstractUserStoreManager.java
@@ -637,10 +637,10 @@ public abstract class AbstractUserStoreManager implements UserStoreManager {
             log.error(message);
             throw new UserStoreException(message);
         }
-        if (!checkUserExistence(adminRoleName)) {
+        if (!checkUserExistence(adminUsername)) {
             handleAdminUserCreation(adminUsername, addAdmin);
         }
-        if (!checkRoleExistence(adminUsername)) {
+        if (!checkRoleExistence(adminRoleName)) {
             handleAdminRoleCreation(adminRoleName, adminUsername, addAdmin);
         }
         assignUserToRole(adminUsername, adminRoleName, addAdmin);

--- a/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
+++ b/monitoring-dashboard/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
@@ -143,6 +143,7 @@ public class DashboardServer {
 
             initSecureVault(parsedConfigs);
             loadConfigurations(parsedConfigs);
+            setJavaxSslTruststore(parsedConfigs);
             ssoConfig = generateSSOConfig(parsedConfigs);
         } catch (SSOConfigException e) {
             logger.error("Error reading SSO configs from TOML file", e);
@@ -446,7 +447,6 @@ public class DashboardServer {
             if (parseResult.get(SSOConstants.TOML_SSO_USER_INFO_ENDPOINT) instanceof String) {
                 userInfoEndpoint = (String) parseResult.get(SSOConstants.TOML_SSO_USER_INFO_ENDPOINT);
             }
-            setJavaxSslTruststore(parseResult);
             return new SSOConfig(oidcAgentConfig, adminGroupAttribute, adminGroups, wellKnownEndpointPath, baseUrl,
                                  introspectionEndpoint, userInfoEndpoint);
         }


### PR DESCRIPTION
## Purpose
> This PR contains following fixes.
- Set client trust store at server startup where earlier it was only set up in case of SSO enabled. 
     -  (https://github.com/wso2/product-micro-integrator/issues/4152)
- Fix issue with User and Role existence checkups. 
     - (https://github.com/wso2/product-micro-integrator/issues/4158)
